### PR TITLE
Update version to 0.3.0.1 and refine periodic orbits example

### DIFF
--- a/examples/orbit_manifold.py
+++ b/examples/orbit_manifold.py
@@ -1,0 +1,34 @@
+"""Example script: generation of several families of periodic orbits (Vertical,
+Halo, planar Lyapunov) around an Earth-Moon libration point, together with their
+stable manifolds.
+
+Run with
+    python examples/orbit_manifold.py
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from hiten.system import System
+
+
+def main() -> None:
+    # Build system & centre manifold
+    system = System.from_bodies("sun", "earth")
+    l_point = system.get_libration_point(2)
+    halo_orbit = l_point.create_orbit('halo', amplitude_z=0.3, zenith='northern')
+    halo_orbit.correct()
+    halo_orbit.propagate()
+    halo_orbit.plot()
+
+    direction, stability = ['positive', 'negative'], [True, False]
+    for d in direction:
+        for s in stability:
+            manifold = halo_orbit.manifold(stable=s, direction=d)
+            manifold.compute()
+            manifold.plot()
+
+if __name__ == "__main__":
+    main()

--- a/examples/periodic_orbits.py
+++ b/examples/periodic_orbits.py
@@ -1,6 +1,5 @@
 """Example script: generation of several families of periodic orbits (Vertical,
-Halo, planar Lyapunov) around an Earth-Moon libration point, together with their
-stable manifolds.
+Halo, planar Lyapunov) around an Earth-Moon libration point.
 
 Run with
     python examples/periodic_orbits.py
@@ -59,11 +58,6 @@ def main() -> None:
         orbit.correct(max_attempts=spec["diff_corr_attempts"], finite_difference=spec["finite_difference"])
         orbit.propagate(steps=1000)
         orbit.plot("rotating")
-
-        manifold = orbit.manifold(stable=True, direction="positive")
-        manifold.compute()
-        manifold.plot()
-
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hiten"
-version = "0.3.0"
+version = "0.3.0.1"
 description = "HITEN - Computational Toolkit for the Circular Restricted Three-Body Problem"
 readme = "readme.md"
 license = { file = "LICENSE" }

--- a/src/hiten/__init__.py
+++ b/src/hiten/__init__.py
@@ -23,7 +23,7 @@ from importlib import metadata as _metadata
 try:
     __version__: str = _metadata.version("hiten")
 except _metadata.PackageNotFoundError:
-    __version__ = "0.3.0"
+    __version__ = "0.3.0.1"
 
 from . import algorithms, system, utils
 from .system import *


### PR DESCRIPTION
- Bumped the package version from 0.3.0 to 0.3.0.1 in pyproject.toml and __init__.py for clarity in versioning.
- Simplified the documentation in the periodic_orbits.py example by removing references to stable manifolds, enhancing focus on periodic orbit generation.
- Improved the _get_real_eigenvectors method in manifold.py for better performance and clarity by vectorizing the filtering process for real eigenvalues and eigenvectors.