### PR TITLE
Review project documentation guidelines

### DIFF
--- a/src/hiten/algorithms/connections/backends.py
+++ b/src/hiten/algorithms/connections/backends.py
@@ -221,7 +221,7 @@ def _refine_pairs_on_section(pu: np.ndarray, ps: np.ndarray, pairs: np.ndarray, 
 
 
 class _ConnectionsBackend:
-    """Encapsulates matching/refinement and ΔV computation for connections."""
+    """Encapsulates matching/refinement and delta-v computation for connections."""
 
     def solve(self, problem):
         # Lazy imports to avoid circulars at module import tim

--- a/src/hiten/algorithms/dynamics/base.py
+++ b/src/hiten/algorithms/dynamics/base.py
@@ -42,9 +42,7 @@ class _DynamicalSystemProtocol(Protocol):
     dim : int
         Dimension of the state vector.
     rhs : Callable[[float, numpy.ndarray], numpy.ndarray]
-        Vector field :math:`f(t,\,\mathbf y)` returning
-        :math:`\dot{\mathbf y}` evaluated at time *t* and state
-        :math:`\mathbf y`.
+        Vector field f(t, y) returning dy/dt evaluated at time t and state y.
     """
     
     @property
@@ -65,7 +63,7 @@ class _DynamicalSystem(ABC):
     Parameters
     ----------
     dim : int
-        Dimension :math:`n \ge 1` of the state space.
+        Dimension n >= 1 of the state space.
 
     Attributes
     ----------

--- a/src/hiten/algorithms/dynamics/rtbp.py
+++ b/src/hiten/algorithms/dynamics/rtbp.py
@@ -153,9 +153,9 @@ def _compute_stm(dynsys, x0, tf, steps=2000, forward=1, method: Literal["scipy",
         Dynamical system exposing the 42-dimensional variational
         equations of the CR3BP.
     x0 : array_like, shape (6,)
-        Initial phase-space state :math:`(x, y, z, \dot x, \dot y, \dot z)`.
+        Initial phase-space state [x, y, z, x_dot, y_dot, z_dot].
     tf : float
-        Final integration time :math:`t_{\mathrm f}`.
+        Final integration time t_f.
     steps : int, default 2000
         Number of output points equally spaced in time.
     forward : int, {1, -1}, default 1
@@ -181,7 +181,7 @@ def _compute_stm(dynsys, x0, tf, steps=2000, forward=1, method: Literal["scipy",
     Notes
     -----
     The STM is embedded into a 42-dimensional vector composed of the 36
-    independent entries of :math:`\Phi(t)` followed by the phase-space
+    independent entries of Phi(t) followed by the phase-space
     variables.  The combined system is then advanced with the selected
     integrator.
     """
@@ -222,12 +222,12 @@ def _compute_monodromy(dynsys, x0, period):
     x0 : array_like, shape (6,)
         Initial state on the periodic orbit.
     period : float
-        Orbital period :math:`T`.
+        Orbital period T.
 
     Returns
     -------
     numpy.ndarray
-        Monodromy matrix :math:`\Phi(T)` of shape *(6, 6)*.
+        Monodromy matrix Phi(T) of shape *(6, 6)*.
     """
     _, _, M, _ = _compute_stm(dynsys, x0, period)
     return M
@@ -245,11 +245,11 @@ def _stability_indices(monodromy):
     Returns
     -------
     tuple
-        Pair :math:`(\nu_1, \nu_2)` where each index is defined as
-        :math:`\nu_i = \tfrac{1}{2}(\lambda_i + 1/\lambda_i)` with
-        :math:`\lambda_i` the corresponding eigenvalue.
+        Pair (nu1, nu2) where each index is defined as
+        nu_i = 0.5 * (lambda_i + 1/lambda_i) with lambda_i the corresponding
+        eigenvalue.
     numpy.ndarray
-        Eigenvalues of *monodromy* sorted by absolute value (descending).
+        Eigenvalues of monodromy sorted by absolute value (descending).
     """
     eigs = np.linalg.eigvals(monodromy)
     
@@ -268,7 +268,7 @@ class _JacobianRHS(_DynamicalSystem):
     Parameters
     ----------
     mu : float
-        Mass parameter :math:`\mu \in (0, 1)`.
+        Mass parameter mu in (0, 1).
     name : str, default 'CR3BP Jacobian'
         Human-readable identifier.
 
@@ -356,7 +356,7 @@ class _RTBPRHS(_DynamicalSystem):
     dim : int
         Always 6.
     rhs : Callable[[float, numpy.ndarray], numpy.ndarray]
-        Vector field :math:`f(t,\mathbf x)`.
+        Vector field f(t, x).
     """
     def __init__(self, mu: float, name: str = "RTBP"):
         super().__init__(dim=6)

--- a/src/hiten/algorithms/fourier/base.py
+++ b/src/hiten/algorithms/fourier/base.py
@@ -25,7 +25,7 @@ from hiten.algorithms.utils.config import FASTMATH
 
 _N_MASK = 0x3F              # 6 bits
 _K_MASK = 0x7F              # 7 bits
-_K_OFFSET = 64              # shift applied to store signed kᵢ as unsigned
+_K_OFFSET = 64              # shift applied to store signed k_i as unsigned
 
 # upper bounds hard-wired by bit-width
 _MAX_N = _N_MASK

--- a/src/hiten/algorithms/hamiltonian/hamiltonian.py
+++ b/src/hiten/algorithms/hamiltonian/hamiltonian.py
@@ -3,17 +3,17 @@ hamiltonian.hamiltonian
 ==================
 
 Construct polynomial representations of the Collinear Restricted Three-Body Problem (CR3BP)
-Hamiltonian and the Lindstedt-Poincaré right-hand sides.
+Hamiltonian and the Lindstedt-Poincare right-hand sides.
 
 The routines generate multivariate polynomials (NumPy arrays wrapped in Numba typed
 lists) that symbolically encode the rotating-frame Hamiltonian up to a prescribed
-truncation degree.  These objects form the algebraic backbone for centre-manifold
+truncation degree.  These objects form the algebraic backbone for center-manifold
 reductions, normal-form computations, and invariant manifold analyses carried out
 elsewhere in the package.
 
 References
 ----------
-Jorba, À., Masdemont, J. (1999). "Dynamics in the center manifold of the collinear points of the restricted
+Jorba, A., Masdemont, J. (1999). "Dynamics in the center manifold of the collinear points of the restricted
 three body problem".
 """
 
@@ -38,14 +38,14 @@ from hiten.algorithms.utils.config import FASTMATH
 def _build_T_polynomials(poly_x, poly_y, poly_z, max_deg: int, psi_table, clmo_table, encode_dict_list) -> types.ListType:
     r"""
     Compute three-dimensional Chebyshev polynomials of the first kind
-    :math:`T_n(r)` where :math:`r = x / \sqrt{x^2 + y^2 + z^2}`.
+    T_n(r) where r = x / sqrt(x^2 + y^2 + z^2).
 
     Parameters
     ----------
     poly_x, poly_y, poly_z : List[np.ndarray]
-        Polynomial representations of the Cartesian coordinates :math:`x,y,z`.
+        Polynomial representations of the Cartesian coordinates x, y, z.
     max_deg : int
-        Highest order :math:`n` such that :math:`T_n` is returned.
+        Highest order n such that T_n is returned.
     psi_table : ndarray
         Combinatorial index table produced by
         :pyfunc:`hiten.algorithms.polynomial.base._init_index_tables`.
@@ -57,7 +57,7 @@ def _build_T_polynomials(poly_x, poly_y, poly_z, max_deg: int, psi_table, clmo_t
     Returns
     -------
     List[List[np.ndarray]]
-        Numba typed list; element *i* holds the coefficients of :math:`	T_i`.
+        Numba typed list; element i holds the coefficients of T_i.
 
     Raises
     ------
@@ -66,9 +66,9 @@ def _build_T_polynomials(poly_x, poly_y, poly_z, max_deg: int, psi_table, clmo_t
     Notes
     -----
     The classical recurrence
-    :math:`T_0 = 1,\; T_1 = r,\; T_n = 2 r\,T_{n-1} - T_{n-2}`
+    T_0 = 1, T_1 = r, T_n = 2*r*T_{n-1} - T_{n-2}
     becomes in Cartesian variables
-    :math:`T_n = \frac{2n-1}{n}\,x\,T_{n-1}-\frac{n-1}{n}\,(x^2 + y^2 + z^2)\,T_{n-2}`.
+    T_n = ((2*n - 1)/n) * x * T_{n-1} - ((n - 1)/n) * (x^2 + y^2 + z^2) * T_{n-2}.
     """
     poly_T_list_of_polys = List()
     for _ in range(max_deg + 1):
@@ -111,13 +111,13 @@ def _build_T_polynomials(poly_x, poly_y, poly_z, max_deg: int, psi_table, clmo_t
 @njit(fastmath=FASTMATH, cache=False)
 def _build_R_polynomials(poly_x, poly_y, poly_z, poly_T: types.ListType, max_deg: int, psi_table, clmo_table, encode_dict_list) -> types.ListType:
     r"""
-    Generate the auxiliary sequence :math:`R_n` required by the Lindstedt-Poincaré
+    Generate the auxiliary sequence R_n required by the Lindstedt-Poincare
     formulation.
 
     Parameters
     ----------
     poly_x, poly_y, poly_z : List[np.ndarray]
-        Polynomial representations of :math:`x,y,z`.
+        Polynomial representations of x, y, z.
     poly_T : List[List[np.ndarray]]
         Output of :pyfunc:`_build_T_polynomials`.
     max_deg, psi_table, clmo_table, encode_dict_list
@@ -126,7 +126,7 @@ def _build_R_polynomials(poly_x, poly_y, poly_z, poly_T: types.ListType, max_deg
     Returns
     -------
     List[List[np.ndarray]]
-        Polynomials :math:`\{R_0,\dots,R_{\text{max\_deg}}\}`.
+        Polynomials {R_0,...,R_max_deg}.
 
     Raises
     ------
@@ -135,15 +135,11 @@ def _build_R_polynomials(poly_x, poly_y, poly_z, poly_T: types.ListType, max_deg
     Notes
     -----
     The recurrence implemented is
-    \[
-      \begin{aligned}
-      R_0 &= -1,\\
-      R_1 &= -3x,\\
-      R_n &= \frac{2n+3}{n+2} x R_{n-1}
-              - \frac{2n+2}{n+2} T_n
-              - \frac{n+1}{n+2}(x^2+y^2+z^2) R_{n-2}.
-      \end{aligned}
-    \]
+      R_0 = -1,
+      R_1 = -3*x,
+      R_n = ((2*n+3)/(n+2)) * x * R_{n-1}
+            - ((2*n+2)/(n+2)) * T_n
+            - ((n+1)/(n+2)) * (x^2 + y^2 + z^2) * R_{n-2}.
     """
     poly_R_list_of_polys = List()
     for _ in range(max_deg + 1):
@@ -212,14 +208,14 @@ def _build_R_polynomials(poly_x, poly_y, poly_z, poly_T: types.ListType, max_deg
 def _build_potential_U(poly_T, point, max_deg: int, psi_table) -> List[np.ndarray]:
     r"""
     Assemble the gravitational potential expansion
-    :math:`U = -\sum_{n\ge 2} c_n T_n(r)`.
+    U = - sum_{n>=2} c_n * T_n(r).
 
     Parameters
     ----------
     poly_T : List[List[np.ndarray]]
         Chebyshev polynomials from :pyfunc:`_build_T_polynomials`.
     point : Any
-        Object exposing ``_cn(k)`` which returns the coefficient :math:`c_k`.
+        Object exposing ``_cn(k)`` which returns the coefficient c_k.
     max_deg : int
         Polynomial truncation degree.
     psi_table : ndarray
@@ -228,7 +224,7 @@ def _build_potential_U(poly_T, point, max_deg: int, psi_table) -> List[np.ndarra
     Returns
     -------
     List[np.ndarray]
-        Polynomial representation of :math:`U`.
+        Polynomial representation of U.
 
     Raises
     ------
@@ -243,7 +239,7 @@ def _build_potential_U(poly_T, point, max_deg: int, psi_table) -> List[np.ndarra
 def _build_kinetic_energy_terms(poly_px, poly_py, poly_pz, max_deg: int, psi_table, clmo_table, encode_dict_list) -> List[np.ndarray]:
     r"""
     Build the kinetic energy term
-    :math:`T = \frac{1}{2}(p_x^2 + p_y^2 + p_z^2)`.
+    T = 0.5 * (p_x^2 + p_y^2 + p_z^2).
 
     Parameters
     ----------
@@ -255,7 +251,7 @@ def _build_kinetic_energy_terms(poly_px, poly_py, poly_pz, max_deg: int, psi_tab
     Returns
     -------
     List[np.ndarray]
-        Polynomial representation of :math:`T`.
+        Polynomial representation of T.
 
     Raises
     ------
@@ -271,7 +267,7 @@ def _build_kinetic_energy_terms(poly_px, poly_py, poly_pz, max_deg: int, psi_tab
 def _build_rotational_terms(poly_x, poly_y, poly_px, poly_py, max_deg: int, psi_table, clmo_table, encode_dict_list) -> List[np.ndarray]:
     r"""
     Construct the Coriolis (rotational) contribution
-    :math:`C = y\,p_x - x\,p_y`.
+    C = y*p_x - x*p_y.
 
     Parameters
     ----------
@@ -285,7 +281,7 @@ def _build_rotational_terms(poly_x, poly_y, poly_px, poly_py, max_deg: int, psi_
     Returns
     -------
     List[np.ndarray]
-        Polynomial representation of :math:`C`.
+        Polynomial representation of C.
 
     Raises
     ------
@@ -305,20 +301,20 @@ def _build_rotational_terms(poly_x, poly_y, poly_px, poly_py, max_deg: int, psi_
 def _build_physical_hamiltonian_collinear(point, max_deg: int) -> List[np.ndarray]:
     r"""
     Combine kinetic, potential, and Coriolis parts to obtain the full
-    rotating-frame Hamiltonian :math:`H = T + U + C`.
+    rotating-frame Hamiltonian H = T + U + C.
 
     Parameters
     ----------
     point : Any
         Object with method ``_cn(k)`` returning the potential coefficient
-        :math:`c_k` of order *k*.
+        c_k of order k.
     max_deg : int
         Truncation degree for every polynomial sub-component.
 
     Returns
     -------
     List[np.ndarray]
-        Hamiltonian coefficients up to *max_deg*.
+        Hamiltonian coefficients up to max_deg.
 
     Raises
     ------
@@ -423,31 +419,26 @@ def _build_A_polynomials(poly_x, poly_y, poly_z, d_x: float, d_y: float, max_deg
 def _build_physical_hamiltonian_triangular(point, max_deg: int) -> List[np.ndarray]:
     r"""
     Construct the rotating-frame Hamiltonian expanded around a triangular
-    (L4/L5) equilibrium to arbitrary polynomial degree *max_deg*.
+    (L4/L5) equilibrium to arbitrary polynomial degree max_deg.
 
     The starting expression is the (already shifted) Hamiltonian quoted in
-    Gómez et al. (2001, eq. 57):
+    Gomez et al. (2001, eq. 57):
 
-    :math:`
-        H = \\tfrac12 (p_x^2 + p_y^2 + p_z^2) + y p_x - x p_y 
-            + \\bigl(\tfrac12 - \\mu\\bigr)\\,x \;\pm\; \\tfrac{\\sqrt{3}}{2}\\,y
-            - \\frac{1-\\mu}{r_{PS}} - \\frac{\\mu}{r_{PJ}}`
+        H = 0.5*(p_x^2 + p_y^2 + p_z^2) + y*p_x - x*p_y 
+            + (0.5 - mu)*x +/- (sqrt(3)/2)*y
+            - (1 - mu)/r_PS - mu/r_PJ
 
-    where the distances to the primaries written in *local* coordinates are
+    where the distances to the primaries written in local coordinates are
 
-    :math:`
-        r_{PS}^2 = (x - x_S)^2 + (y - y_S)^2 + z^2,\\,
-        r_{PJ}^2 = (x - x_J)^2 + (y - y_J)^2 + z^2,\\,
-        (x_S, y_S) = \\bigl(\\, +\\tfrac12, \; s \\tfrac{\\sqrt{3}}{2}\\bigr),\\qquad
-        (x_J, y_J) = \\bigl(\\, -\\tfrac12, \; s \\tfrac{\\sqrt{3}}{2}\\bigr)`
+        r_PS^2 = (x - x_S)^2 + (y - y_S)^2 + z^2,
+        r_PJ^2 = (x - x_J)^2 + (y - y_J)^2 + z^2,
+        (x_S, y_S) = (+1/2, s*sqrt(3)/2), (x_J, y_J) = (-1/2, s*sqrt(3)/2)
 
-    with *s = +1* for L4 and *s = -1* for L5.  At the equilibrium the
+    with s = +1 for L4 and s = -1 for L5.  At the equilibrium the
     distances equal one, hence we may expand each inverse distance with the
     binomial series
 
-    :math:`
-        \\frac{1}{r} = \\bigl(1 + u\\bigr)^{-1/2} = \\sum_{k\\ge 0} \\binom{-1/2}{k}
-        u^k, \\qquad u = r^2 - 1.`
+        1/r = (1 + u)^(-1/2) = sum_{k>=0} binom(-1/2, k) * u^k,  where u = r^2 - 1.
     """
     psi_table, clmo_table = _init_index_tables(max_deg)
     encode_dict_list = _create_encode_dict_from_clmo(clmo_table)
@@ -522,12 +513,12 @@ def _build_physical_hamiltonian_triangular(point, max_deg: int) -> List[np.ndarr
 
 def _build_lindstedt_poincare_rhs_polynomials(point, max_deg: int) -> Tuple[List, List, List]:
     r"""
-    Compute RHS polynomials for the first Lindstedt-Poincaré iteration.
+    Compute RHS polynomials for the first Lindstedt-Poincare iteration.
 
     Parameters
     ----------
     point : Any
-        Provider of the sequence :math:`c_k` via ``_cn``.
+        Provider of the sequence c_k via ``_cn``.
     max_deg : int
         Truncation degree.
 

--- a/src/hiten/algorithms/integrators/base.py
+++ b/src/hiten/algorithms/integrators/base.py
@@ -6,15 +6,15 @@ Abstract interfaces for numerical time integration.
 
 The module provides two core abstractions:
 
-* :pyclass:`_Solution` - an immutable container that stores a time grid, the
+- :pyclass:`_Solution` - an immutable container that stores a time grid, the
   associated state vectors, and, optionally, the vector field evaluations so
   that the trajectory can be queried by cubic Hermite interpolation.
-* :pyclass:`_Integrator` - an abstract base class that prescribes the public
+- :pyclass:`_Integrator` - an abstract base class that prescribes the public
   API for every concrete one-step or multi-step integrator.
 
 References
 ----------
-Hairer, E., Nørsett, S. P., & Wanner, G. (1993). "Solving Ordinary
+Hairer, E., Norsett, S. P., & Wanner, G. (1993). "Solving Ordinary
 Differential Equations I: Non-stiff Problems".
 """
 
@@ -34,12 +34,12 @@ class _Solution:
 
     Parameters
     ----------
-    times : numpy.ndarray, shape (:math:`n`,)
+    times : numpy.ndarray, shape (n,)
         Monotonically ordered time grid.
-    states : numpy.ndarray, shape (:math:`n`, :math:`d`)
+    states : numpy.ndarray, shape (n, d)
         State vectors corresponding to *times*.
-    derivatives : numpy.ndarray or None, optional, shape (:math:`n`, :math:`d`)
-        Evaluations of :math:`f(t,\mathbf y)` at the stored nodes. When
+    derivatives : numpy.ndarray or None, optional, shape (n, d)
+        Evaluations of f(t, y) at the stored nodes. When
         available a cubic Hermite interpolant is employed by
         :pyfunc:`_Solution.interpolate`; otherwise linear interpolation is used.
 
@@ -86,13 +86,13 @@ class _Solution:
         ----------
         t : float or array_like
             Query time or array of times contained in
-            :math:`[\text{times}[0],\,\text{times}[-1]]`.
+            [times[0], times[-1]].
 
         Returns
         -------
         numpy.ndarray
-            Interpolated state with shape (:math:`d`,) when *t* is scalar or
-            (:math:`m`, :math:`d`) when *t* comprises :math:`m` points.
+            Interpolated state with shape (d,) when *t* is scalar or
+            (m, d) when *t* comprises m points.
 
         Raises
         ------

--- a/src/hiten/algorithms/integrators/rk.py
+++ b/src/hiten/algorithms/integrators/rk.py
@@ -9,8 +9,8 @@ formal order of accuracy.
 
 The concrete schemes implemented are:
 
-* Fixed step: _RK4, _RK6, _RK8
-* Adaptive embedded: _RK45 (Dormand-Prince) and _DOP853 (Dormand-Prince 8(5,3))
+- Fixed step: _RK4, _RK6, _RK8
+- Adaptive embedded: _RK45 (Dormand-Prince) and _DOP853 (Dormand-Prince 8(5,3))
 
 Internally the module also defines helper routines to evaluate Hamiltonian
 vector fields with :pyfunc:`numba.njit` and to wrap right-hand side (RHS)
@@ -75,7 +75,7 @@ class _RungeKuttaBase(_Integrator):
     Attributes
     ----------
     _A : numpy.ndarray of shape (s, s)
-        Strictly lower triangular array of stage coefficients :math:`a_{ij}`.
+        Strictly lower triangular array of stage coefficients a_ij.
     _B_HIGH : numpy.ndarray of shape (s,)
         Weights of the high order solution.
     _B_LOW : numpy.ndarray or None
@@ -83,7 +83,7 @@ class _RungeKuttaBase(_Integrator):
         estimate is produced and :pyfunc:`_rk_embedded_step` falls back to
         the high order result for both outputs.
     _C : numpy.ndarray of shape (s,)
-        Nodes :math:`c_i` measured in units of the step size.
+        Nodes c_i measured in units of the step size.
     _p : int
         Formal order of accuracy of the high order scheme.
 
@@ -131,9 +131,9 @@ class _FixedStepRK(_RungeKuttaBase):
     name : str
         Human readable identifier of the scheme (e.g. ``"_RK4"``).
     A, B, C : numpy.ndarray
-        Butcher tableau as returned by :pymod:`hiten.algorithms.integrators.coefficients.*`.
+        Butcher tableau as returned by the coefficients modules.
     order : int
-        Formal order of accuracy :math:`p` of the method.
+        Formal order of accuracy p of the method.
     **options
         Additional keyword options forwarded to the base :class:`_Integrator`.
 
@@ -217,7 +217,7 @@ class _AdaptiveStepRK(_RungeKuttaBase):
     the error estimates returned by :pyfunc:`_rk_embedded_step`.  Two safety
     factors are used:
 
-    * *rtol*, *atol*  - user requested relative and absolute tolerances
+    - rtol, atol  - user requested relative and absolute tolerances
     * :pyattr:`SAFETY` - hard coded damping on the acceptance criterion.
 
     Parameters
@@ -228,7 +228,7 @@ class _AdaptiveStepRK(_RungeKuttaBase):
         Relative and absolute error tolerances.  Defaults are read from
         :pydata:`hiten.utils.config.TOL`.
     max_step : float, optional
-        Upper bound on the step size.  :math:`\infty` by default.
+        Upper bound on the step size.  Infinity by default.
     min_step : float or None, optional
         Lower bound on the step size.  When *None* the value is derived from
         machine precision.

--- a/src/hiten/algorithms/integrators/symplectic.py
+++ b/src/hiten/algorithms/integrators/symplectic.py
@@ -3,7 +3,7 @@ hiten.algorithms.integrators.symplectic
 ================================
 
 High-order explicit symplectic integrators for polynomial Hamiltonian
-systems with :math:`n_\text{dof}=3`.  The module provides two layers of
+systems with n_dof=3.  The module provides two layers of
 functionality:
 
 * Low-level, :pyfunc:`numba.njit` accelerated kernels that implement the
@@ -128,7 +128,7 @@ def _eval_dH_dQ(
     Returns
     -------
     numpy.ndarray
-        Vector of partial derivatives ∂H/∂Q (e.g., [∂H/∂q1, ∂H/∂q2, ∂H/∂q3])
+        Vector of partial derivatives dH/dQ (e.g., [dH/dq1, dH/dq2, dH/dq3])
     """
     eval_point_6d = _construct_6d_eval_point(Q_eval_ndof, P_eval_ndof)
     
@@ -166,7 +166,7 @@ def _eval_dH_dP(
     Returns
     -------
     numpy.ndarray
-        Vector of partial derivatives ∂H/∂P (e.g., [∂H/∂p1, ∂H/∂p2, ∂H/∂p3])
+        Vector of partial derivatives dH/dP (e.g., [dH/dp1, dH/dp2, dH/dp3])
     """
     eval_point_6d = _construct_6d_eval_point(Q_eval_ndof, P_eval_ndof)
     
@@ -188,7 +188,7 @@ def _phi_H_a_update_poly(
     clmo_H: List[np.ndarray]
     ):
     r"""
-    Apply the first Hamiltonian splitting operator (φₐ) in the symplectic scheme.
+    Apply the first Hamiltonian splitting operator (phi_a) in the symplectic scheme.
     
     Parameters
     ----------
@@ -204,8 +204,8 @@ def _phi_H_a_update_poly(
     Notes
     -----
     Implements the symplectic update step:
-    - P ← P - delta ·∂H/∂Q(Q,Y)
-    - X ← X + delta ·∂H/∂P(Q,Y)
+    - P <- P - delta * dH/dQ(Q, Y)
+    - X <- X + delta * dH/dP(Q, Y)
     
     This modifies q_ext in-place through views/slices.
     Q, P, X, Y are now N_SYMPLECTIC_DOF dimensional.
@@ -232,7 +232,7 @@ def _phi_H_b_update_poly(
     clmo_H: List[np.ndarray]
     ):
     r"""
-    Apply the second Hamiltonian splitting operator (φᵦ) in the symplectic scheme.
+    Apply the second Hamiltonian splitting operator (phi_b) in the symplectic scheme.
     
     Parameters
     ----------
@@ -248,8 +248,8 @@ def _phi_H_b_update_poly(
     Notes
     -----
     Implements the symplectic update step:
-    - Q ← Q + delta ·∂H/∂P(X,P)
-    - Y ← Y - delta ·∂H/∂Q(X,P)
+    - Q <- Q + delta * dH/dP(X, P)
+    - Y <- Y - delta * dH/dQ(X, P)
     
     This modifies q_ext in-place through views/slices.
     Q, P, X, Y are now N_SYMPLECTIC_DOF dimensional.
@@ -271,7 +271,7 @@ def _phi_H_b_update_poly(
 @njit(cache=False, fastmath=FASTMATH)
 def _phi_omega_H_c_update_poly(q_ext: np.ndarray, delta: float, omega: float):
     r"""
-    Apply the rotation operator (φᶜ) in the symplectic scheme.
+    Apply the rotation operator (phi_c) in the symplectic scheme.
     
     Parameters
     ----------
@@ -349,7 +349,7 @@ def _recursive_update_poly(
     Notes
     -----
     For order=2, applies the basic second-order symplectic scheme:
-        φₐ(delta /2) ∘ φᵦ(delta /2) ∘ φᶜ(delta ) ∘ φᵦ(delta /2) ∘ φₐ(delta /2)
+        phi_a(delta/2) o phi_b(delta/2) o phi_c(delta) o phi_b(delta/2) o phi_a(delta/2)
     
     For higher orders, applies a recursive composition method with
     carefully chosen substeps to achieve the desired order of accuracy.

--- a/src/hiten/system/base.py
+++ b/src/hiten/system/base.py
@@ -5,7 +5,7 @@ hiten.system.base
 High-level abstractions for the Circular Restricted Three-Body Problem (CR3BP).
 
 This module bundles the physical information of a binary system, computes the
-mass parameter :math:`\mu`, instantiates the underlying vector field via
+mass parameter mu, instantiates the underlying vector field via
 :pyfunc:`hiten.algorithms.dynamics.rtbp.rtbp_dynsys`, and pre-computes the five
 classical Lagrange (libration) points.
 
@@ -113,7 +113,7 @@ class System(object):
 
     @property
     def mu(self) -> float:
-        r"""Mass parameter :math:`\mu`."""
+        r"""Mass parameter mu."""
         return self._mu
 
     @property
@@ -138,13 +138,13 @@ class System(object):
         Returns
         -------
         float
-            Value of :math:`\mu`.
+            Value of mu.
 
         Notes
         -----
         The calculation is performed in high precision using
         :pyfunc:`hiten.utils.precision.hp` to mitigate numerical cancellation when
-        :math:`m_1 \approx m_2`.
+        the two masses are nearly equal.
         """
         logger.debug(f"Calculating mu: {self.secondary.mass} / ({self.primary.mass} + {self.secondary.mass})")
 

--- a/src/hiten/system/libration/base.py
+++ b/src/hiten/system/libration/base.py
@@ -6,9 +6,9 @@ Abstract helpers to model Libration points of the Circular Restricted Three-Body
 
 The module introduces two primary abstractions:
 
-* :pyclass:`LinearData` - an immutable record storing the salient linear characteristics (eigenfrequencies and canonical basis) of the flow linearised at a libration point.
-* :pyclass:`LibrationPoint` - an abstract base class encapsulating geometry, energetic properties, linear stability analysis and lazy construction of centre-manifold normal forms. 
-   Concrete subclasses implement the specific coordinates of the collinear (:math:`L_1`, :math:`L_2`, :math:`L_3`) and triangular (:math:`L_4`, :math:`L_5`) points.
+- :pyclass:`LinearData` - an immutable record storing the salient linear characteristics (eigenfrequencies and canonical basis) of the flow linearised at a libration point.
+- :pyclass:`LibrationPoint` - an abstract base class encapsulating geometry, energetic properties, linear stability analysis and lazy construction of center-manifold normal forms. 
+   Concrete subclasses implement the specific coordinates of the collinear (L1, L2, L3) and triangular (L4, L5) points.
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -41,21 +41,21 @@ class LinearData:
     Parameters
     ----------
     mu : float
-        Mass ratio :math:`\mu := m_2/(m_1+m_2)` of the primaries.
+        Mass ratio mu := m2/(m1+m2) of the primaries.
     point : str
         Identifier of the libration point (``'L1'``, ``'L2'`` or ``'L3'``).
     lambda1 : float | None
-        Real hyperbolic eigenvalue :math:`\lambda_1>0` associated with the
+        Real hyperbolic eigenvalue lambda_1 > 0 associated with the
         saddle behaviour along the centre-saddle subspace.
     omega1 : float
-        First elliptic frequency :math:`\omega_1>0` of the centre subspace.
+        First elliptic frequency omega_1 > 0 of the center subspace.
     omega2 : float
-        Second elliptic frequency :math:`\omega_2>0` of the centre subspace.
+        Second elliptic frequency omega_2 > 0 of the center subspace.
     omega3: float | None
-        Vertical frequency :math:`\omega_3` of the centre subspace.
+        Vertical frequency omega_3 of the center subspace.
     C : numpy.ndarray, shape (6, 6)
-        Symplectic change-of-basis matrix such that :math:`C^{-1}AC` is in real
-        Jordan canonical form, with :math:`A` the Jacobian of the vector
+        Symplectic change-of-basis matrix such that C^{-1} A C is in real
+        Jordan canonical form, with A the Jacobian of the vector
         field evaluated at the libration point.
     Cinv : numpy.ndarray, shape (6, 6)
         Precomputed inverse of :pyattr:`C`.
@@ -83,13 +83,13 @@ class LibrationPoint(ABC):
     Parameters
     ----------
     system : hiten.system.base.System
-        Parent CR3BP model providing the mass ratio :math:`\mu` and utility
+        Parent CR3BP model providing the mass ratio mu and utility
         functions.
 
     Attributes
     ----------
     mu : float
-        Mass ratio :math:`\mu` of the primaries (copied from *system*).
+        Mass ratio mu of the primaries (copied from *system*).
     system : hiten.system.base.System
         Reference to the owner hiten.system.
     position : numpy.ndarray, shape (3,)
@@ -99,7 +99,7 @@ class LibrationPoint(ABC):
         Dimensionless mechanical energy evaluated via
         :pyfunc:`hiten.algorithms.dynamics.hiten.utils.energy.crtbp_energy`.
     jacobi_constant : float
-        Jacobi integral :math:`C_J = -2E` corresponding to
+        Jacobi integral C_J = -2E corresponding to
         :pyattr:`energy`.
     is_stable : bool
         True if all eigenvalues returned by :pyfunc:`analyze_stability` lie

--- a/src/hiten/system/libration/collinear.py
+++ b/src/hiten/system/libration/collinear.py
@@ -2,7 +2,7 @@ r"""
 hiten.system.libration.collinear
 ==========================
 
-Collinear libration points :math:`L_1`, :math:`L_2` and :math:`L_3` of the circular restricted three body problem (CR3BP).
+Collinear libration points L1, L2 and L3 of the circular restricted three body problem (CR3BP).
 
 The module defines:
 

--- a/src/hiten/system/libration/triangular.py
+++ b/src/hiten/system/libration/triangular.py
@@ -2,12 +2,12 @@ r"""
 hiten.system.libration.triangular
 ==========================
 
-Triangular Libration points (:math:`L_4` and :math:`L_5`) of the Circular Restricted Three-Body Problem (CR3BP).
+Triangular Libration points (L4 and L5) of the Circular Restricted Three-Body Problem (CR3BP).
 
 The module defines:
 
-* :pyclass:`TriangularPoint` - an abstract helper encapsulating the geometry shared by the triangular points.
-* :pyclass:`L4Point` and :pyclass:`L5Point` - concrete equilibria located at +-60° with respect to the line connecting the primaries.
+- :pyclass:`TriangularPoint` - an abstract helper encapsulating the geometry shared by the triangular points.
+- :pyclass:`L4Point` and :pyclass:`L5Point` - concrete equilibria located at +-60 deg with respect to the line connecting the primaries.
 """
 
 from typing import TYPE_CHECKING
@@ -26,20 +26,20 @@ class TriangularPoint(LibrationPoint):
     Abstract helper for the triangular Libration points.
 
     The triangular points form equilateral triangles with the two primary
-    bodies. They behave as centre-type equilibria when the mass ratio
-    :math:`\mu` is below Routh's critical value.
+    bodies. They behave as center-type equilibria when the mass ratio
+    mu is below Routh's critical value.
 
     Parameters
     ----------
     system : System
-        CR3BP model supplying the mass parameter :math:`\mu`.
+        CR3BP model supplying the mass parameter mu.
 
     Attributes
     ----------
     mu : float
-        Mass ratio :math:`\mu = m_2 / (m_1 + m_2)` taken from *system*.
+        Mass ratio mu = m2 / (m1 + m2) taken from *system*.
     ROUTH_CRITICAL_MU : float
-        Critical value :math:`\mu_R` delimiting linear stability.
+        Critical value mu_R delimiting linear stability.
     sign : int
         +1 for :pyclass:`L4Point`, -1 for :pyclass:`L5Point`.
     a : float
@@ -47,7 +47,7 @@ class TriangularPoint(LibrationPoint):
 
     Notes
     -----
-    A warning is logged if :math:`\mu > \mu_R`.
+    A warning is logged if mu > mu_R.
     """
     ROUTH_CRITICAL_MU = (1.0 - np.sqrt(1.0 - (1.0/27.0))) / 2.0 # approx 0.03852
     

--- a/src/hiten/system/orbits/base.py
+++ b/src/hiten/system/orbits/base.py
@@ -7,13 +7,13 @@ in the circular restricted three-body problem (CR3BP).
 
 The module provides:
 
-* :pyclass:`PeriodicOrbit` - an abstract base class that implements common
+- :pyclass:`PeriodicOrbit` - an abstract base class that implements common
   functionality such as energy evaluation, propagation wrappers, plotting and
   differential correction.
-* :pyclass:`GenericOrbit` - a minimal concrete implementation useful for
+- :pyclass:`GenericOrbit` - a minimal concrete implementation useful for
   arbitrary initial conditions when no analytical guess or specific correction
   is required.
-* Light-weight configuration containers (:pyclass:`_OrbitCorrectionConfig`) that 
+- Light-weight configuration containers (:pyclass:`_OrbitCorrectionConfig`) that 
   encapsulate user input for differential correction settings.
 
 References
@@ -69,7 +69,7 @@ class PeriodicOrbit(ABC):
         The libration point instance that anchors the family.
     initial_state : Sequence[float] or None, optional
         Initial condition in rotating canonical units
-        :math:`[x, y, z, \dot x, \dot y, \dot z]`. When *None* an analytical
+        [x, y, z, x_dot, y_dot, z_dot]. When *None* an analytical
         approximation is attempted.
 
     Attributes


### PR DESCRIPTION
Update docstrings and comments to comply with ASCII-only, plain-text math, and consistent bullet style documentation guidelines.

This PR converts Sphinx math roles to ASCII plain-text, replaces Unicode characters with ASCII equivalents, and standardizes bullet points from '*' to '-' in several core modules.

---
<a href="https://cursor.com/background-agent?bcId=bc-556907f5-f50a-4963-8f6d-cdaace8a583a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-556907f5-f50a-4963-8f6d-cdaace8a583a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

