### PR TITLE
Review mdc documentation guidelines

### DIFF
--- a/src/hiten/algorithms/connections/backends.py
+++ b/src/hiten/algorithms/connections/backends.py
@@ -17,7 +17,7 @@ See Also
 from typing import Tuple
 
 import numpy as np
-from numba import njit
+from numba import njit  # external, referenced in plain text per docs
 
 from hiten.algorithms.connections.results import _ConnectionResult
 
@@ -109,8 +109,8 @@ def _radpair2d(query: np.ndarray, ref: np.ndarray, radius: float) -> np.ndarray:
 
     Notes
     -----
-    Uses :func:`_pair_counts` and :func:`_exclusive_prefix_sum` to efficiently
-    allocate and populate the output array.
+    Uses :func:`_pair_counts` and :func:`_exclusive_prefix_sum` to
+    efficiently allocate and populate the output array.
     """
     r2 = float(radius) * float(radius)
     counts = _pair_counts(query, ref, r2)
@@ -154,7 +154,8 @@ def _radius_pairs_2d(query: np.ndarray, ref: np.ndarray, radius: float) -> np.nd
     Notes
     -----
     This is the main entry point for 2D radius-based pairing. It prepares
-    contiguous arrays and delegates to the numba-accelerated :func:`_radpair2d`.
+    contiguous arrays and delegates to the numba accelerated
+    :func:`_radpair2d`.
     """
     q = np.ascontiguousarray(query, dtype=np.float64)
     r = np.ascontiguousarray(ref, dtype=np.float64)
@@ -178,7 +179,8 @@ def _nearest_neighbor_2d_numba(points: np.ndarray) -> np.ndarray:
 
     Notes
     -----
-    This is the numba-accelerated implementation used by :func:`_nearest_neighbor_2d`.
+    This is the numba accelerated implementation used by
+    :func:`_nearest_neighbor_2d`.
     """
     n = points.shape[0]
     out = np.full(n, -1, dtype=np.int64)
@@ -216,7 +218,7 @@ def _nearest_neighbor_2d(points: np.ndarray) -> np.ndarray:
 
     Notes
     -----
-    This function prepares data and delegates to the numba-accelerated
+    This function prepares data and delegates to the numba accelerated
     :func:`_nearest_neighbor_2d_numba`.
     """
     p = np.ascontiguousarray(points, dtype=np.float64)
@@ -416,26 +418,27 @@ class _ConnectionsBackend:
 
         Parameters
         ----------
-        problem : object
-            Problem specification containing source/target sections, search parameters,
-            and synodic section definition.
+        problem : :class:`hiten.algorithms.connections.engine._ConnectionProblem`
+            Problem specification containing source/target sections, search
+            parameters, and synodic section definition.
 
         Returns
         -------
         list of :class:`hiten.algorithms.connections.results._ConnectionResult`
-            Connection results sorted by increasing delta_v (velocity change)
-            required for the transfer.
+            Connection results sorted by increasing Delta-V (velocity
+            change) required for the transfer.
 
         Notes
         -----
         The algorithm performs these steps:
-        1. Build section hits using ``problem.source.to_section()`` and ``problem.target.to_section()``
+        1. Build section hits using
+           ``problem.source.to_section()`` and ``problem.target.to_section()``
         2. Coarse 2D radius pairing via :func:`_radius_pairs_2d`
-        3. Mutual-nearest filtering to reduce false positives
-        4. On-section refinement via :func:`_refine_pairs_on_section`
+        3. Mutual nearest filtering to reduce false positives
+        4. On section refinement via :func:`_refine_pairs_on_section`
         5. Delta-V computation and classification (ballistic vs impulsive)
         """
-        # Lazy imports to avoid circulars at module import tim
+        # Lazy imports to avoid circular imports at module import time
         # 1) Build section hits on the provided synodic section
         sec_u = problem.source.to_section(problem.section, direction=problem.direction)
         sec_s = problem.target.to_section(problem.section, direction=problem.direction)

--- a/src/hiten/algorithms/connections/base.py
+++ b/src/hiten/algorithms/connections/base.py
@@ -95,23 +95,23 @@ class Connection:
     >>> manifold_l2.compute(integration_fraction=1.0, step=0.005)
     >>> 
     >>> section_cfg = SynodicMapConfig(
-    >>>     section_axis="x",
-    >>>     section_offset=1 - mu,
-    >>>     plane_coords=("y", "z"),
-    >>>     interp_kind="cubic",
-    >>>     segment_refine=30,
-    >>>     tol_on_surface=1e-9,
-    >>>     dedup_time_tol=1e-9,
-    >>>     dedup_point_tol=1e-9,
-    >>>     max_hits_per_traj=None,
-    >>>     n_workers=None,
-    >>> )
+    ...     section_axis="x",
+    ...     section_offset=1 - mu,
+    ...     plane_coords=("y", "z"),
+    ...     interp_kind="cubic",
+    ...     segment_refine=30,
+    ...     tol_on_surface=1e-9,
+    ...     dedup_time_tol=1e-9,
+    ...     dedup_point_tol=1e-9,
+    ...     max_hits_per_traj=None,
+    ...     n_workers=None,
+    ... )
     >>> 
     >>> conn = Connection(
-    >>>     section=section_cfg,
-    >>>     direction=None,
-    >>>     search_cfg=SearchConfig(delta_v_tol=1, ballistic_tol=1e-8, eps2d=1e-3),
-    >>> )
+    ...     section=section_cfg,
+    ...     direction=None,
+    ...     search_cfg=SearchConfig(delta_v_tol=1, ballistic_tol=1e-8, eps2d=1e-3),
+    ... )
     >>> 
     >>> conn.solve(manifold_l1, manifold_l2)
     >>> print(conn)

--- a/src/hiten/algorithms/connections/engine.py
+++ b/src/hiten/algorithms/connections/engine.py
@@ -71,7 +71,11 @@ class _ConnectionProblem:
     >>> 
     >>> source_if = _ManifoldInterface(manifold=unstable_manifold)
     >>> target_if = _ManifoldInterface(manifold=stable_manifold)
-    >>> section_cfg = _SynodicMapConfig(x=0.8)
+    >>> section_cfg = _SynodicMapConfig(
+    ...     section_axis="x",
+    ...     section_offset=0.8,
+    ...     plane_coords=("y", "z")
+    ... )
     >>> search_cfg = _SearchConfig(delta_v_tol=1e-3)
     >>> 
     >>> problem = _ConnectionProblem(

--- a/src/hiten/algorithms/connections/interfaces.py
+++ b/src/hiten/algorithms/connections/interfaces.py
@@ -70,7 +70,11 @@ class _ManifoldInterface:
     >>> 
     >>> # Assuming manifold is computed
     >>> interface = _ManifoldInterface(manifold=computed_manifold)
-    >>> section_cfg = _SynodicMapConfig(x=0.8)
+    >>> section_cfg = _SynodicMapConfig(
+    ...     section_axis="x",
+    ...     section_offset=0.8,
+    ...     plane_coords=("y", "z")
+    ... )
     >>> section = interface.to_section(config=section_cfg, direction=1)
     >>> print(f"Found {len(section.points)} intersection points")
 


### PR DESCRIPTION
Update docstrings and Sphinx references in the `connections/` module to comply with `@docs.mdc` guidelines.

This PR standardizes Sphinx cross-references (using plain text for external libraries and local names for in-file references), corrects doctest prompts in examples, and refines docstring content for clarity and consistency, including fixing typos and standardizing parameter types.

---
<a href="https://cursor.com/background-agent?bcId=bc-92e6532f-c7d2-4218-83f2-50b4201f7fe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92e6532f-c7d2-4218-83f2-50b4201f7fe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

