### PR TITLE
Review mdc documentation guidelines

### DIFF
--- a/src/hiten/algorithms/dynamics/rhs.py
+++ b/src/hiten/algorithms/dynamics/rhs.py
@@ -68,7 +68,7 @@ class _RHSSystem(_DynamicalSystem):
     --------
     :class:`hiten.algorithms.dynamics.base._DynamicalSystem` : Base class
     :func:`create_rhs_system` : Factory function
-    :func:`numba.njit` : JIT compilation used internally
+    numba njit : JIT compilation used internally
     """
 
     def __init__(self, rhs_func: Callable[[float, np.ndarray], np.ndarray], dim: int, name: str = "Generic RHS"):

--- a/src/hiten/algorithms/dynamics/utils/linalg.py
+++ b/src/hiten/algorithms/dynamics/utils/linalg.py
@@ -36,10 +36,10 @@ def eigenvalue_decomposition(A: np.ndarray, discrete: int = 0, delta: float = 1e
     discrete : int, optional
         Classification mode. Default is 0.
         
-        * 0 : Continuous-time system (Jacobian matrix)
-              Uses sign(Re{lambda}) for classification
-        * 1 : Discrete-time system (map matrix)
-              Uses |lambda| with neutral band for classification
+        - 0 : Continuous-time system (Jacobian matrix)
+          Uses sign(Re{lambda}) for classification
+        - 1 : Discrete-time system (map matrix)
+          Uses |lambda| with neutral band for classification
     delta : float, optional
         Half-width of neutral band around stability threshold. Default is 1e-4.
         For continuous systems: |Re{lambda}| < delta -> center


### PR DESCRIPTION
Audit and fix docstring formatting in the `dynamics` module to comply with `docs.mdc` guidelines.

Specifically, this PR replaces an external Sphinx role with plain text and converts star bullets to hyphens, adhering to the project's documentation standards for external references and list formatting.

---
<a href="https://cursor.com/background-agent?bcId=bc-2984a730-7192-416e-9d9a-b4818911d891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2984a730-7192-416e-9d9a-b4818911d891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

