### PR TITLE
Review mdc documentation guidelines

### DIFF
--- a/src/hiten/algorithms/corrector/__init__.py
+++ b/src/hiten/algorithms/corrector/__init__.py
@@ -18,7 +18,7 @@ Most users will work with the ready-to-use correctors:
 
 >>> from hiten.algorithms.corrector import _NewtonOrbitCorrector
 >>> corrector = _NewtonOrbitCorrector()
->>> corrected_orbit = corrector.correct(orbit)
+>>> x_corr, t_half = corrector.correct(orbit)
 
 Advanced users can create custom correctors by combining components:
 

--- a/src/hiten/algorithms/corrector/_step_interface.py
+++ b/src/hiten/algorithms/corrector/_step_interface.py
@@ -469,7 +469,7 @@ class _ArmijoStepInterface(_PlainStepInterface):
     >>> interface = _ArmijoStepInterface(line_search_config=False)
     >>>
     >>> # Custom line search configuration
-    >>> config = _LineSearchConfig(c1=1e-4, rho=0.5, max_iter=20)
+    >>> config = _LineSearchConfig(armijo_c=1e-4, alpha_reduction=0.5, min_alpha=1e-4)
     >>> interface = _ArmijoStepInterface(line_search_config=config)
 
     See Also

--- a/src/hiten/algorithms/corrector/base.py
+++ b/src/hiten/algorithms/corrector/base.py
@@ -143,11 +143,11 @@ class _BaseCorrectionConfig:
         safeguard against excessively large steps that could cause numerical
         overflow or move far from the solution. Particularly important for
         poorly conditioned problems or bad initial guesses.
-    line_search_config : _LineSearchConfig, bool, or None, default=True
+    line_search_config : :class:`hiten.algorithms.corrector.line._LineSearchConfig`, bool, or None, default=True
         Configuration for line search behavior:
         - True: Enable line search with default parameters
         - False or None: Disable line search (use full Newton steps)
-        - _LineSearchConfig: Enable line search with custom parameters
+        - :class:`hiten.algorithms.corrector.line._LineSearchConfig`: Enable line search with custom parameters
         Line search improves robustness for challenging problems at the
         cost of additional function evaluations.
     finite_difference : bool, default=False
@@ -185,7 +185,7 @@ class _BaseCorrectionConfig:
     >>>
     >>> # Robust configuration with custom line search
     >>> from hiten.algorithms.corrector.line import _LineSearchConfig
-    >>> ls_config = _LineSearchConfig(c1=1e-4, rho=0.5)
+    >>> ls_config = _LineSearchConfig(armijo_c=1e-4, alpha_reduction=0.5)
     >>> config = _BaseCorrectionConfig(
     ...     line_search_config=ls_config,
     ...     max_delta=1e-3
@@ -216,7 +216,7 @@ class _BaseCorrectionConfig:
     Controls the line search behavior for step-size control:
     - True: Use default line search parameters for robust convergence
     - False or None: Disable line search, use full Newton steps
-    - _LineSearchConfig: Use custom line search parameters
+    - :class:`hiten.algorithms.corrector.line._LineSearchConfig`: Use custom line search parameters
     
     Line search is generally recommended for production use as it
     significantly improves convergence robustness, especially for

--- a/src/hiten/algorithms/corrector/correctors.py
+++ b/src/hiten/algorithms/corrector/correctors.py
@@ -31,11 +31,11 @@ class _NewtonOrbitCorrector(_PeriodicOrbitCorrectorInterface, _NewtonCore):
     Examples
     --------
     >>> corrector = _NewtonOrbitCorrector()
-    >>> corrected_orbit = corrector.correct_orbit(initial_orbit)
+    >>> x_corr, t_half = corrector.correct(initial_orbit)
     >>>
     >>> # High-precision correction
     >>> corrector = _NewtonOrbitCorrector(tol=1e-12, max_attempts=100)
-    >>> precise_orbit = corrector.correct_orbit(orbit)
+    >>> x_corr, t_half = corrector.correct(orbit)
 
     See Also
     --------

--- a/src/hiten/algorithms/corrector/interfaces.py
+++ b/src/hiten/algorithms/corrector/interfaces.py
@@ -39,7 +39,7 @@ class _OrbitCorrectionConfig(_BaseCorrectionConfig):
         Additional Jacobian contribution function.
     target : tuple of float, default=(0.0,)
         Target values for the residual components.
-    event_func : callable, default=_y_plane_crossing
+    event_func : :func:`hiten.algorithms.poincare.singlehit.backend._y_plane_crossing`, default=_y_plane_crossing
         Function to detect Poincare section crossings.
     method : str, default="scipy"
         Integration method for trajectory computation.
@@ -138,7 +138,7 @@ class _PeriodicOrbitCorrectorInterface(_Corrector):
         
         Parameters
         ----------
-        orbit : PeriodicOrbit
+        orbit : :class:`hiten.system.orbits.base.PeriodicOrbit`
             Orbit object containing system information.
         x_full : ndarray
             Initial state for integration.
@@ -183,7 +183,7 @@ class _PeriodicOrbitCorrectorInterface(_Corrector):
         ----------
         p_vec : ndarray
             Current parameter vector.
-        orbit : PeriodicOrbit
+        orbit : :class:`hiten.system.orbits.base.PeriodicOrbit`
             Orbit being corrected.
         base_state : ndarray
             Base state vector.
@@ -253,7 +253,7 @@ class _PeriodicOrbitCorrectorInterface(_Corrector):
         ----------
         p_vec : ndarray
             Current parameter vector.
-        orbit : PeriodicOrbit
+        orbit : :class:`hiten.system.orbits.base.PeriodicOrbit`
             Orbit being corrected.
         base_state : ndarray
             Base state vector.
@@ -329,7 +329,7 @@ class _PeriodicOrbitCorrectorInterface(_Corrector):
         
         Parameters
         ----------
-        orbit : PeriodicOrbit
+        orbit : :class:`hiten.system.orbits.base.PeriodicOrbit`
             Orbit to be corrected.
         tol : float, default=1e-10
             Convergence tolerance for residual norm.

--- a/src/hiten/algorithms/corrector/newton.py
+++ b/src/hiten/algorithms/corrector/newton.py
@@ -72,7 +72,7 @@ class _NewtonCore(_ArmijoStepInterface, _Corrector, ABC):
         iterations : int
             Total iterations performed.
         residual_norm : float
-            Final residual norm (≤ tolerance).
+            Final residual norm (<= tolerance).
         """
         pass
 
@@ -89,7 +89,7 @@ class _NewtonCore(_ArmijoStepInterface, _Corrector, ABC):
         iterations : int
             Total iterations performed.
         residual_norm : float
-            Final residual norm (≥ tolerance).
+            Final residual norm (>= tolerance).
         """
         pass
 
@@ -139,7 +139,7 @@ class _NewtonCore(_ArmijoStepInterface, _Corrector, ABC):
         """Compute Jacobian matrix J(x) = dR/dx.
 
         Uses analytical Jacobian if provided, otherwise computes central
-        finite-difference approximation with O(h²) accuracy.
+        finite-difference approximation with O(h^2) accuracy.
 
         Parameters
         ----------


### PR DESCRIPTION
Standardize docstrings in the `corrector` module to comply with `docs.mdc` guidelines.

This includes fixing ASCII-only characters, correcting example parameter names and usage, and adding full Sphinx cross-references for types and functions, ensuring all documentation aligns with the project's standards.

---
<a href="https://cursor.com/background-agent?bcId=bc-694f8d29-6a84-431a-8994-758d1f82df63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-694f8d29-6a84-431a-8994-758d1f82df63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

