### PR TITLE
Update algorithm and system documentation structure

### DIFF
--- a/docs/api/algorithms.rst
+++ b/docs/api/algorithms.rst
@@ -17,5 +17,4 @@ systems analysis in the CR3BP.
    algorithms/hamiltonian
    algorithms/poincare
    algorithms/polynomial/index
-   algorithms/tori
    algorithms/utils

--- a/docs/api/system.rst
+++ b/docs/api/system.rst
@@ -15,3 +15,4 @@ dynamical systems in the Circular Restricted Three-Body Problem (CR3BP).
    system/orbits
    system/libration
    system/hamiltonians
+   system/torus


### PR DESCRIPTION
- Removed the `algorithms/tori` entry from the algorithms documentation to streamline content.
- Added the `system/torus` entry to the system documentation, enhancing the coverage of available system components.
- Improved overall organization of the documentation for better clarity and usability.